### PR TITLE
[XPU] Added a new skip test to detect if the world size is set to non-power of 2

### DIFF
--- a/test/distributed/fsdp/test_fsdp_tp_integration.py
+++ b/test/distributed/fsdp/test_fsdp_tp_integration.py
@@ -25,7 +25,11 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
     RowwiseParallel,
 )
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_distributed import (
+    skip_if_lt_x_gpu,
+    skip_if_not_powerof2_worldsize_xpu,
+
+)
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -230,6 +234,7 @@ class TestTPFSDPIntegration(FSDPTest):
         return torch.cat(all_grads_per_param).contiguous()
 
     @skip_if_lt_x_gpu(4)
+    @skip_if_not_powerof2_worldsize_xpu()
     def test_fsdp_tp_integration(self):
         self.run_subtests(
             {

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -85,6 +85,8 @@ TEST_SKIPS = {
     "importerror": TestSkip(88, "Test skipped due to missing import"),
     "no_accelerator": TestSkip(89, "accelerator is not available."),
     "not-support-multithread": TestSkip(90, "backend not support multithread."),
+    "power-of-two": TestSkip(91, "world size needs to be power of two on xpu."),
+    "worldsize-not-set": TestSkip(92, "world size not set"),
 }
 
 
@@ -204,6 +206,25 @@ def skip_if_lt_x_gpu(x):
             if TEST_XPU and torch.xpu.device_count() >= x:
                 return func(*args, **kwargs)
             sys.exit(TEST_SKIPS[f"multi-gpu-{x}"].exit_code)
+
+        return wrapper
+
+    return decorator
+
+
+def skip_if_not_powerof2_worldsize_xpu():
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if TEST_XPU:
+                if os.getenv("WORLD_SIZE") is not None:
+                    x = int(os.getenv("WORLD_SIZE"))
+                    print(f"skip_if_not_powerof2_worldsize_xpu x: {x}")
+                    if TEST_XPU and ((x & (x - 1)) == 0):
+                        return func(*args, **kwargs)
+                    sys.exit(TEST_SKIPS[f"power-of-two"].exit_code)
+                sys.exit(TEST_SKIPS[f"worldsize-not-set"].exit_code)
+            return func(*args, **kwargs)
 
         return wrapper
 

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -86,7 +86,6 @@ TEST_SKIPS = {
     "no_accelerator": TestSkip(89, "accelerator is not available."),
     "not-support-multithread": TestSkip(90, "backend not support multithread."),
     "power-of-two": TestSkip(91, "world size needs to be power of two on xpu."),
-    "worldsize-not-set": TestSkip(92, "world size not set"),
 }
 
 
@@ -217,13 +216,11 @@ def skip_if_not_powerof2_worldsize_xpu():
         @wraps(func)
         def wrapper(*args, **kwargs):
             if TEST_XPU:
-                if os.getenv("WORLD_SIZE") is not None:
-                    x = int(os.getenv("WORLD_SIZE"))
-                    print(f"skip_if_not_powerof2_worldsize_xpu x: {x}")
-                    if TEST_XPU and ((x & (x - 1)) == 0):
-                        return func(*args, **kwargs)
-                    sys.exit(TEST_SKIPS[f"power-of-two"].exit_code)
-                sys.exit(TEST_SKIPS[f"worldsize-not-set"].exit_code)
+                x = torch.xpu.device_count()
+                print(f"skip_if_not_powerof2_worldsize_xpu x: {x}")
+                if (x & (x - 1)) == 0:
+                    return func(*args, **kwargs)
+                sys.exit(TEST_SKIPS[f"power-of-two"].exit_code)
             return func(*args, **kwargs)
 
         return wrapper


### PR DESCRIPTION
[XPU] Added a new skip test to detect if the world size is set to non power-of-two for XPU and XCCL backend. The skip test relies on WORLD_SIZE being set. If WORLD_SIZE is not set, the test case is skipped. Used this skip-test for test/distributed/fsdp/test_fsdp_tp_integration.py as it is not designed when non-power-of-two, e.g., 12, ranks is used as WORLD_SIZE. The test case is not skipped when 4 or 8 ranks are used for XPU devices. The test case is not skipped for a non-XPU device.


