### PR TITLE
Adjust error tolerance for oneDNN nondeterministic

### DIFF
--- a/test/distributed/pipelining/test_backward.py
+++ b/test/distributed/pipelining/test_backward.py
@@ -15,7 +15,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     precisionOverride,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import run_tests, TestCase, TEST_XPU
 
 
 d_hid = 512
@@ -23,7 +23,7 @@ batch_size = 256
 
 
 class StageBackwardTests(TestCase):
-    @precisionOverride({torch.float: 1e-4})
+    @precisionOverride({torch.float: 1e-4} if TEST_XPU else {})
     @dtypes(torch.float)
     def test_stage_backward(self, device, dtype):
         # MLP as a stage module
@@ -99,7 +99,7 @@ class StageBackwardTests(TestCase):
             # Check that the weight gradients were not updated
             self.assertEqual(p.grad, None)
 
-    @precisionOverride({torch.float: 1e-4})
+    @precisionOverride({torch.float: 1e-4} if TEST_XPU else {})
     @dtypes(torch.float)
     def test_stage_backward_weight(self, device, dtype):
         # MLP as a stage module
@@ -141,7 +141,7 @@ class StageBackwardTests(TestCase):
                 print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
                 raise
 
-    @precisionOverride({torch.float: 1e-4})
+    @precisionOverride({torch.float: 1e-4} if TEST_XPU else {})
     @dtypes(torch.float)
     def test_stage_backward_weight_multiple_iters(self, device, dtype):
         # MLP as a stage module

--- a/test/distributed/pipelining/test_backward.py
+++ b/test/distributed/pipelining/test_backward.py
@@ -10,7 +10,11 @@ from torch.distributed.pipelining._backward import (
     stage_backward_input,
     stage_backward_weight,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    dtypes,
+    instantiate_device_type_tests,
+    precisionOverride,
+)
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -19,7 +23,9 @@ batch_size = 256
 
 
 class StageBackwardTests(TestCase):
-    def test_stage_backward(self, device):
+    @precisionOverride({torch.float: 1e-4})
+    @dtypes(torch.float)
+    def test_stage_backward(self, device, dtype):
         # MLP as a stage module
         mod = MLPModule(d_hid).to(device)
         x = torch.randn(batch_size, d_hid, device=device)
@@ -53,7 +59,7 @@ class StageBackwardTests(TestCase):
         for name, p in mod.named_parameters():
             ref_p = ref_mod.get_parameter(name)
             try:
-                torch.testing.assert_close(p.grad, ref_p.grad)
+                self.assertEqual(p.grad, ref_p.grad)
             except AssertionError:
                 print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
                 raise
@@ -93,7 +99,9 @@ class StageBackwardTests(TestCase):
             # Check that the weight gradients were not updated
             self.assertEqual(p.grad, None)
 
-    def test_stage_backward_weight(self, device):
+    @precisionOverride({torch.float: 1e-4})
+    @dtypes(torch.float)
+    def test_stage_backward_weight(self, device, dtype):
         # MLP as a stage module
         mod = MLPModule(d_hid).to(device)
         x = torch.randn(batch_size, d_hid, device=device)
@@ -128,12 +136,14 @@ class StageBackwardTests(TestCase):
         for name, p in mod.named_parameters():
             ref_p = ref_mod.get_parameter(name)
             try:
-                torch.testing.assert_close(p.grad, ref_p.grad)
+                self.assertEqual(p.grad, ref_p.grad)
             except AssertionError:
                 print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
                 raise
 
-    def test_stage_backward_weight_multiple_iters(self, device):
+    @precisionOverride({torch.float: 1e-4})
+    @dtypes(torch.float)
+    def test_stage_backward_weight_multiple_iters(self, device, dtype):
         # MLP as a stage module
         mod = MLPModule(d_hid).to(device)
         inputs = []
@@ -178,7 +188,7 @@ class StageBackwardTests(TestCase):
         for name, p in mod.named_parameters():
             ref_p = ref_mod.get_parameter(name)
             try:
-                torch.testing.assert_close(p.grad, ref_p.grad)
+                self.assertEqual(p.grad, ref_p.grad)
             except AssertionError:
                 print(f"Gradient test failed for {name}: {p.grad} vs {ref_p.grad}")
                 raise

--- a/test/distributed/pipelining/test_microbatch.py
+++ b/test/distributed/pipelining/test_microbatch.py
@@ -9,7 +9,11 @@ from torch.distributed.pipelining.microbatch import (
     split_args_kwargs_into_chunks,
     TensorChunkSpec,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    dtypes,
+    instantiate_device_type_tests,
+    precisionOverride,
+)
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -56,7 +60,9 @@ class MicrobatchTests(TestCase):
         torch.testing.assert_close(merged_kwargs, kwargs)
         print("Microbatch test passed")
 
-    def test_chunk_spec(self, device):
+    @precisionOverride({torch.float: 2e-4})
+    @dtypes(torch.float)
+    def test_chunk_spec(self, device, dtype):
         mod = ModelWithKwargs().to(device)
         batch_size = ModelWithKwargs.DEFAULT_BATCH_SIZE
 
@@ -84,7 +90,7 @@ class MicrobatchTests(TestCase):
 
         ref = mod(x, y)
         out = pipe(x, y)[0]
-        torch.testing.assert_close(out, ref)
+        self.assertEqual(out, ref)
         print(f"equivalence test passed {torch.sum(out)} ref {torch.sum(ref)}")
 
 

--- a/test/distributed/pipelining/test_microbatch.py
+++ b/test/distributed/pipelining/test_microbatch.py
@@ -14,7 +14,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     precisionOverride,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import run_tests, TestCase, TEST_XPU
 
 
 d_hid = 512
@@ -60,7 +60,7 @@ class MicrobatchTests(TestCase):
         torch.testing.assert_close(merged_kwargs, kwargs)
         print("Microbatch test passed")
 
-    @precisionOverride({torch.float: 2e-4})
+    @precisionOverride({torch.float: 2e-4} if TEST_XPU else {})
     @dtypes(torch.float)
     def test_chunk_spec(self, device, dtype):
         mod = ModelWithKwargs().to(device)


### PR DESCRIPTION
This is to fix https://github.com/intel/torch-xpu-ops/issues/1682

Some of the distributed UTs are failed due to accuracy gap introduced by oneDNN non-deterministic and this gap is not distributed specific. Following previous practice, this PR increases their error tolerance.

`precisionOverride` cannot control behavior of `torch.testing.assert_close`, so I replaced them with `self.assertEqual` since these two are equivalent in terms of comparing. If this is not acceptable for upstreaming, I can instead explicitly adjust atol/rtol in `torch.testing.assert_close`.