### PR TITLE
Preserve RNG state for XPU in checkpointing

### DIFF
--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1311,14 +1311,14 @@ def functionalize_rng_ops(
 
         for candidate in candidates:
             if isinstance(candidate, torch.Tensor):
-                if candidate.device.type == "cuda":
+                if candidate.device.type in ["cuda", "xpu"]:
                     return candidate.device
 
         return torch.device("cpu")
 
     def get_sample_rng_state(device: Optional[torch.device]):
-        if device is not None and device.type == "cuda":
-            return torch.cuda.get_rng_state()
+        if device is not None and device.type in ["cuda", "xpu"]:
+            return torch.get_device_module().get_rng_state()
         return torch.get_rng_state()
 
     # Step 1 - Construct a mapping of rng node between the fwd and its counterpart in bwd.


### PR DESCRIPTION
Fixes a problem in `test/distributed/test_dynamo_distributed.py TestMultiProc.test_hf_bert_fsdp_activation_checkpointing` where during the checkpointing process the XPU rng state was not being properly saved and overwriting the CPU rng state.

See https://jira.devtools.intel.com/browse/PYTORCHDGQ-6376