### PR TITLE
Add check to verify if local shards in FSDP have tensors before accessing

### DIFF
--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -1890,7 +1890,7 @@ class TestFSDPOptimState(FSDPTest):
                     if s.dim() == 0:
                         continue
                     self.assertTrue(isinstance(s, ShardedTensor))
-                    if s._local_shards[0]:
+                    if len(s._local_shards) > 0:
                         self.assertTrue(s._local_shards[0].tensor.is_xpu) if device_type == 'xpu' else self.assertTrue(s._local_shards[0].tensor.is_cuda)
 
         # Test full state_dict with rank0_only


### PR DESCRIPTION
Fixes #PYTORCHDGQ-6374. The existing test (`TestFSDPOptimState.test_interface_arguments`) accesses `local_shards[0]` in FSDP for all ranks by default. Based on the number of ranks and data, not all ranks will have local shards with tensor every time. Accessing empty `local_shards` throws a `list index out of range` error. Adding a check before accessing elements resolves this for all cases.