### PR TITLE
Fix special gpu_num cases for test_parallelize_api

### DIFF
--- a/test/distributed/tensor/parallel/test_parallelize_api.py
+++ b/test/distributed/tensor/parallel/test_parallelize_api.py
@@ -34,7 +34,7 @@ class TensorParallelAPITests(DTensorTestBase):
     @property
     def world_size(self):
         gpu_num = torch.accelerator.device_count()
-        return gpu_num if gpu_num % 2 == 0 and gpu_num > 4 else 4
+        return gpu_num if gpu_num % 2 == 0 and gpu_num > 4 and 16 % gpu_num == 0 else 4
 
     def _compare_params(
         self,


### PR DESCRIPTION
This is to fix PYTORCHDGQ-7110. Currently, the row-wise partition in UT will fail on machines with 6 or 12 gpus. 
