### PR TITLE
Fix asseration error ut

### DIFF
--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -442,6 +442,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         )
         rank = dist.get_rank()
         device_type = torch.accelerator.current_accelerator().type
+        
         device = f"xpu:{dist.get_rank()}"
         model_to_save = MyShardedModel3(src_spec).to(device)
         model_to_save._register_state_dict_hook(state_dict_hook)

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -357,7 +357,13 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
             )
             # In this case `.wait_tensor(y)` in compiled region will not be able to find the corresponding work object
             # to invoke the wait, thus the result will not match eager.
-            self.assertNotEqual(out_ref, out_compiled)
+            if not torch.xpu.is_available():
+                if torch.equal(out_ref, out_compiled):
+                    raise AssertionError("Expected outputs to differ due to missing wait_tensor, but they matched")
+            else:
+                print("XPU detected - skipping output mismatch check (all reduce likely completed synchronously")
+
+            #self.assertNotEqual(out_ref, out_compiled)
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -361,7 +361,6 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
                 if torch.equal(out_ref, out_compiled):
                     raise AssertionError("Expected outputs to differ due to missing wait_tensor, but they matched")
             else:
-
                 print("XPU detected - skipping output mismatch check (all reduce likely completed synchronously")
 
             #self.assertNotEqual(out_ref, out_compiled)

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -361,6 +361,7 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
                 if torch.equal(out_ref, out_compiled):
                     raise AssertionError("Expected outputs to differ due to missing wait_tensor, but they matched")
             else:
+
                 print("XPU detected - skipping output mismatch check (all reduce likely completed synchronously")
 
             #self.assertNotEqual(out_ref, out_compiled)


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

This unit test assumes the outputs will be different because CUDA doesn't implicitly synchronize collectives. 
On XPU, XCCL backend does implicitly synchronize during certain tensor ops so the mismatch doesn't happen.

As a sanity check , I tested the output :

[RANK 0] out_ref sum: {4096000000.0}
[RANK 1] out_ref sum: {4096000000.0}
[RANK 0] out_compiled sum: {4096000000.0}
[RANK 1] out_compiled sum: {4096000000.0}
[RANK 0] Equal?  {True}

To fix, check for xpu available to skip assertion
 