### PR TITLE
Skip CPU tests for DataParallelDeviceType

### DIFF
--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -16,7 +16,7 @@ from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
     dtypes,
     instantiate_device_type_tests,
-    onlyCUDAAndXPU,
+    onlyOn,
     skipMeta,
 )
 from torch.testing._internal.common_utils import (
@@ -958,7 +958,7 @@ class TestDataParallel(TestCase):
 
 
 class TestDataParallelDeviceType(TestCase):
-    @onlyCUDAAndXPU
+    @onlyOn(["cuda", "xpu"])
     @skipMeta
     @dtypes(torch.float, torch.double, torch.half)
     def test_data_parallel_module(self, device, dtype):
@@ -970,7 +970,7 @@ class TestDataParallelDeviceType(TestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
-    @onlyCUDAAndXPU
+    @onlyOn(["cuda", "xpu"])
     @skipMeta
     @dtypes(torch.float, torch.double, torch.half)
     def test_data_parallel_module_kwargs_only(self, device, dtype):
@@ -990,7 +990,7 @@ class TestDataParallelDeviceType(TestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
-    @onlyCUDAAndXPU
+    @onlyOn(["cuda", "xpu"])
     @skipMeta
     @dtypes(torch.float, torch.double, torch.half)
     def test_data_parallel_module_kwargs_only_empty_list(self, device, dtype):
@@ -1010,7 +1010,7 @@ class TestDataParallelDeviceType(TestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
-    @onlyCUDAAndXPU
+    @onlyOn(["cuda", "xpu"])
     @skipMeta
     @dtypes(torch.float, torch.double, torch.half)
     def test_data_parallel_module_kwargs_only_empty_dict(self, device, dtype):
@@ -1030,7 +1030,7 @@ class TestDataParallelDeviceType(TestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
-    @onlyCUDAAndXPU
+    @onlyOn(["cuda", "xpu"])
     @skipMeta
     @dtypes(torch.float, torch.double, torch.half)
     def test_data_parallel_module_kwargs_only_empty_tuple(self, device, dtype):

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -16,7 +16,7 @@ from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
     dtypes,
     instantiate_device_type_tests,
-    onlyCUDA,
+    onlyCUDAAndXPU,
     skipMeta,
 )
 from torch.testing._internal.common_utils import (
@@ -958,6 +958,7 @@ class TestDataParallel(TestCase):
 
 
 class TestDataParallelDeviceType(TestCase):
+    @onlyCUDAAndXPU
     @skipMeta
     @dtypes(torch.float, torch.double, torch.half)
     def test_data_parallel_module(self, device, dtype):
@@ -969,6 +970,7 @@ class TestDataParallelDeviceType(TestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
+    @onlyCUDAAndXPU
     @skipMeta
     @dtypes(torch.float, torch.double, torch.half)
     def test_data_parallel_module_kwargs_only(self, device, dtype):
@@ -988,6 +990,7 @@ class TestDataParallelDeviceType(TestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
+    @onlyCUDAAndXPU
     @skipMeta
     @dtypes(torch.float, torch.double, torch.half)
     def test_data_parallel_module_kwargs_only_empty_list(self, device, dtype):
@@ -1007,6 +1010,7 @@ class TestDataParallelDeviceType(TestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
+    @onlyCUDAAndXPU
     @skipMeta
     @dtypes(torch.float, torch.double, torch.half)
     def test_data_parallel_module_kwargs_only_empty_dict(self, device, dtype):
@@ -1026,6 +1030,7 @@ class TestDataParallelDeviceType(TestCase):
         self.assertEqual(out.get_device(), 0)
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
+    @onlyCUDAAndXPU
     @skipMeta
     @dtypes(torch.float, torch.double, torch.half)
     def test_data_parallel_module_kwargs_only_empty_tuple(self, device, dtype):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1698,18 +1698,6 @@ def onlyCUDAAndPRIVATEUSE1(fn):
     return only_fn
 
 
-def onlyCUDAAndXPU(fn):
-    @wraps(fn)
-    def only_fn(self, *args, **kwargs):
-        if self.device_type not in ("cuda", "xpu"):
-            reason = f"onlyCUDAAndXPU: doesn't run on {self.device_type}"
-            raise unittest.SkipTest(reason)
-
-        return fn(self, *args, **kwargs)
-
-    return only_fn
-
-
 def disablecuDNN(fn):
     @wraps(fn)
     def disable_cudnn(self, *args, **kwargs):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1698,6 +1698,18 @@ def onlyCUDAAndPRIVATEUSE1(fn):
     return only_fn
 
 
+def onlyCUDAAndXPU(fn):
+    @wraps(fn)
+    def only_fn(self, *args, **kwargs):
+        if self.device_type not in ("cuda", "xpu"):
+            reason = f"onlyCUDAAndXPU: doesn't run on {self.device_type}"
+            raise unittest.SkipTest(reason)
+
+        return fn(self, *args, **kwargs)
+
+    return only_fn
+
+
 def disablecuDNN(fn):
     @wraps(fn)
     def disable_cudnn(self, *args, **kwargs):


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/2728

In upstream, these tests are intended to be skipped for CPU