### PR TITLE
Enable other skip tests in test/distributed/test_c10d_xccl.py

### DIFF
--- a/test/distributed/test_c10d_xccl.py
+++ b/test/distributed/test_c10d_xccl.py
@@ -47,7 +47,7 @@ import torch.testing._internal.common_utils as common
 from torch import nn
 from torch._C._distributed_c10d import ErrorType, OpType, WorkResult
 from torch.nn.parallel import DistributedDataParallel
-from torch.testing._internal.common_cuda import _get_torch_rocm_version, TEST_MULTIGPU
+from torch.testing._internal.common_utils import TEST_MULTIGPU 
 from torch.testing._internal.common_distributed import (
     get_required_world_size,
     get_timeout,
@@ -5728,7 +5728,7 @@ class XCCLTraceTest(XCCLTraceTestBase):
                     # Therefore, the state can either be scheduled or started before test dumps the trace.
                     if (
                         torch.version.hip
-                        and _get_torch_rocm_version() >= (6, 4)
+                        # and _get_torch_rocm_version() >= (6, 4)
                         and timing_enabled
                     ):
                         assert t[-1]["state"] in ("scheduled", "started")

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -15,7 +15,7 @@ import unittest
 CUDA_ALREADY_INITIALIZED_ON_IMPORT = torch.cuda.is_initialized()
 
 
-TEST_MULTIGPU = TEST_CUDA and torch.cuda.device_count() >= 2
+TEST_MULTIGPU = (TEST_CUDA or TEST_XPU) and torch.accelerator.device_count() >= 2
 CUDA_DEVICE = torch.device("cuda:0") if TEST_CUDA else None
 # note: if ROCm is targeted, TEST_CUDNN is code for TEST_MIOPEN
 if TEST_WITH_ROCM:

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -15,7 +15,7 @@ import unittest
 CUDA_ALREADY_INITIALIZED_ON_IMPORT = torch.cuda.is_initialized()
 
 
-TEST_MULTIGPU = (TEST_CUDA or TEST_XPU) and torch.accelerator.device_count() >= 2
+TEST_MULTIGPU = TEST_CUDA and torch.cuda.device_count() >= 2
 CUDA_DEVICE = torch.device("cuda:0") if TEST_CUDA else None
 # note: if ROCm is targeted, TEST_CUDNN is code for TEST_MIOPEN
 if TEST_WITH_ROCM:

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -277,7 +277,7 @@ def requires_world_size(n: int):
 
     def decorator(func):
         func._required_world_size = n
-        available = torch.cuda.device_count()
+        available = torch.accelerator.device_count()
         return unittest.skipUnless(
             available >= n, f"requires {n} GPUs, found {available}"
         )(func)


### PR DESCRIPTION
Enabling other skip tests in test/distributed/test_c10d_xccl.py(minor changes) that were skipped due to cuda flags.