### PR TITLE
Fix typo in TestShardingSpec::test_chunked_sharding_spec

### DIFF
--- a/test/distributed/_shard/sharding_spec/test_sharding_spec.py
+++ b/test/distributed/_shard/sharding_spec/test_sharding_spec.py
@@ -87,7 +87,7 @@ class TestShardingSpec(TestCase):
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
             ChunkShardingSpec(0, ["random:0", f"{device_type}:1"])
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, [f"rank:0/{device_type}:foo", f"{device_type}:1"])
+            ChunkShardingSpec(0, [f"{device_type}:foo", f"{device_type}:1"])
         with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
             ChunkShardingSpec(0, ["rank:foo", f"{device_type}:1"])
         with self.assertRaisesRegex(RuntimeError, "Expected one of"):


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/3102. The cause seems to be a typo when adapting             [ChunkShardingSpec(0, ["cuda:foo", "cuda:1"])](https://github.com/pytorch/pytorch/blob/5f66c4b154ec5d963fd1331b7ab9b9fa4a2ca37e/test/distributed/_shard/sharding_spec/test_sharding_spec.py#L87), otherwise we are testing the same case again in L94.
