### PR TITLE
Use DeterministicGuard in DDP test to also enable XPU

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4917,9 +4917,12 @@ class DistributedTest:
                 ):
                     self.assertEqual(p1, p2, "Parameters not initially equal!")
                 # Enable determinism in cudnn operators
-                with torch.backends.cudnn.flags(
-                    enabled=True, deterministic=True, benchmark=False
-                ), DeterministicGuard(True):
+                with (
+                    torch.backends.cudnn.flags(
+                        enabled=True, deterministic=True, benchmark=False
+                    ),
+                    DeterministicGuard(True),
+                ):
                     for i in range(8):
                         inp = (
                             torch.randn(1, 3, 1000, 1000, device=device_type)

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -86,6 +86,7 @@ from torch.testing._internal.common_distributed import (
     with_nccl_blocking_wait,
 )
 from torch.testing._internal.common_utils import (
+    DeterministicGuard,
     FILE_SCHEMA,
     instantiate_parametrized_tests,
     IS_FBCODE,
@@ -4918,7 +4919,7 @@ class DistributedTest:
                 # Enable determinism in cudnn operators
                 with torch.backends.cudnn.flags(
                     enabled=True, deterministic=True, benchmark=False
-                ):
+                ), DeterministicGuard(True):
                     for i in range(8):
                         inp = (
                             torch.randn(1, 3, 1000, 1000, device=device_type)


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/2752

`TestDistBackendWithSpawn` in `test/distributed/test_distributed_spawn.py` uses `_test_ddp_apply_optim_in_backward` from `distributed_test.py`. The backward pass uses the following context:
 ```with torch.backends.cudnn.flags(enabled=True, deterministic=True, benchmark=False)```

However, this doesn't set determinism in the XPU backend. This PR adds a `DeterministicGuard(True)` context as well, to ensure the XPU call is also deterministic.


Regarding upstream PR: I made a [PR ](https://github.com/pytorch/pytorch/pull/181644) upstream which can't be merged, because there is a dependency on XPU specific code which is only in this branch and not in upstream, so I think it just needs to be merged here and then merged later with other test code.