### PR TITLE
Disable efficient attention support check for XPU

### DIFF
--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -95,8 +95,6 @@ def evaluate_platform_supports_efficient_attention():
         return evaluate_gfx_arch_within(arch_list)
     if TEST_CUDA:
         return True
-    if TEST_XPU:
-        return True
     return False
 
 def evaluate_platform_supports_cudnn_attention():

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -96,7 +96,7 @@ def evaluate_platform_supports_efficient_attention():
     if TEST_CUDA:
         return True
     if TEST_XPU:
-        return True
+        return False
     return False
 
 def evaluate_platform_supports_cudnn_attention():


### PR DESCRIPTION
 ## Summary
  - Fixes https://github.com/intel/torch-xpu-ops/issues/3232
  - SDPA Memory Efficient Attention backend is not supported on XPU, causing test failures in `test/distributed/tensor/test_attention.py` due to math fallback
  - Return `False` for XPU in `evaluate_platform_supports_efficient_attention()` to prevent these tests from running with the unsupported backend
