### PR TITLE
[XPU] Enable TestComplexTensor on XPU

### DIFF
--- a/test/complex_tensor/test_complex_tensor.py
+++ b/test/complex_tensor/test_complex_tensor.py
@@ -171,7 +171,7 @@ class TestComplexBwdGradients(TestCase):
         self.check_grad(device, dtype, op)
 
 
-instantiate_device_type_tests(TestComplexTensor, globals())
+instantiate_device_type_tests(TestComplexTensor, globals(), allow_xpu=True)
 instantiate_device_type_tests(TestComplexBwdGradients, globals())
 
 


### PR DESCRIPTION
## Summary
- Enable XPU variants for `TestComplexTensor` by extending `instantiate_device_type_tests` with `allow_xpu=True` in `test/complex_tensor/test_complex_tensor.py`.
- Scope is intentionally limited to this single test-file change; no `op_db`/`DecorateInfo` widening was required for this class.
- No new XPU skip decorators were added and existing skip behavior is unchanged.

## Test Plan
- Environment: `classify_ut_test` conda env, `torch==2.13.0+xpu`, `torch.xpu.is_available()==True`
- Command (cwd: `test/complex_tensor`):
  ```
  python -m pytest test_complex_tensor.py -k TestComplexTensorXPU -v --timeout 600 --timeout_method=thread
  ```
- Result: `253 passed, 6 skipped, 0 failed, 0 xpass, 554 deselected`
- Skip rationale: the 6 skips are expected (`empty_like`/`randn_like` non-deterministic and existing `SKIPS` dict behavior).

Authored with an AI assistant.