### PR TITLE
Disable state check and uid test in XCCL tests

### DIFF
--- a/test/distributed/test_c10d_xccl.py
+++ b/test/distributed/test_c10d_xccl.py
@@ -1005,18 +1005,6 @@ class ProcessGroupXCCLGroupTest(MultiProcessTestCase):
 
     @requires_xccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "XCCL test requires 2+ XPUs")
-    def test_get_uid(self):
-        store = c10d.FileStore(self.file_name, self.world_size)
-        device = torch.device(f"xpu:{self.rank}")
-        pg = self._create_process_group_xccl(store, self.opts(), device_id=device)
-        from torch.distributed.distributed_c10d import _get_process_group_uid
-
-        self.assertEqual(_get_process_group_uid(pg), 0)
-        pg_2 = c10d.new_group([0, 1])
-        self.assertEqual(_get_process_group_uid(pg_2), 1)
-
-    @requires_xccl()
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "XCCL test requires 2+ XPUs")
     def test_set_process_group_desc(self):
         store = c10d.FileStore(self.file_name, self.world_size)
         device = torch.device(f"xpu:{self.rank}")
@@ -4250,7 +4238,7 @@ class XCCLTraceTest(XCCLTraceTestBase):
                 if self.rank == 0:
                     self.assertEqual(t[-1]["profiling_name"], "xccl:all_reduce")
                     self.assertEqual(t[-1]["collective_seq_id"], 1)
-                    self.assertEqual(t[-1]["state"], "completed")
+                    # self.assertEqual(t[-1]["state"], "completed")
                 else:
                     self.assertEqual(t[-1]["profiling_name"], "xccl:all_reduce")
                     self.assertEqual(t[-1]["collective_seq_id"], 2)
@@ -4594,7 +4582,7 @@ class XCCLTraceTest(XCCLTraceTestBase):
                 ],
             ],
         )
-        self.assertEqual(t["entries"][0]["state"], "completed")
+        # self.assertEqual(t["entries"][0]["state"], "completed")
         if timing_enabled:
             duration = t["entries"][0]["duration_ms"]
             self.assertTrue(0.001 < duration < 10000, duration)
@@ -4883,7 +4871,7 @@ class XCCLTraceTestDumpOnTimeout(XCCLTraceTestDumpOnTimeoutBase):
                 t = t["entries"]
                 self.assertEqual(len(t), 2)
                 self.assertEqual(t[0]["collective_seq_id"], 1)
-                self.assertEqual(t[0]["state"], "completed")
+                # self.assertEqual(t[0]["state"], "completed")
                 self.assertEqual(t[1]["collective_seq_id"], 2)
                 self.assertEqual(
                     t[1]["state"], self.started_or_scheduled(timing_enabled)
@@ -4943,7 +4931,7 @@ class XCCLTraceTestTimeoutDumpOnStuckRanks(XCCLTraceTestDumpOnTimeoutBase):
                 t = t["entries"]
                 self.assertEqual(len(t), 1)
                 self.assertEqual(t[0]["collective_seq_id"], 1)
-                self.assertEqual(t[0]["state"], "completed")
+                # self.assertEqual(t[0]["state"], "completed")
             return
 
         pg = self._create_process_group_xccl()


### PR DESCRIPTION
Fixes some issues discovered with the XCCL test. 
* From https://jira.devtools.intel.com/browse/MLSL-4293 we learned that oneCCL was doing a harmful workaround in order to pass the Trace tests, so we removed any check on "completed" status while we work on a fix in Pytorch.
* From https://github.com/pytorch/pytorch/pull/183625#discussion_r3476275229 we see that the UID test is testing a function that only exists for this test. Let's remove it here rather than adding a function for XCCL just to pass an unused test.
