### PR TITLE
[Distributed] Add Debug flag for test_monitored_barrier_allreduce_hang for XCCL backend

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -8948,6 +8948,9 @@ class DistributedTest:
 
         def _test_monitored_barrier_allreduce_hang(self, wait_all_ranks):
             # tests expected behavior when nonzero rank hangs.
+            # This test requires DETAIL debug flag to match error regex on xccl
+             if TEST_XPU:
+                dist.set_debug_level(dist.DebugLevel.DETAIL)
             backend_pg = dist.new_group(
                 ranks=list(range(int(self.world_size))),
                 # provide sufficient timeout so communicators

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -8949,7 +8949,7 @@ class DistributedTest:
         def _test_monitored_barrier_allreduce_hang(self, wait_all_ranks):
             # tests expected behavior when nonzero rank hangs.
             # This test requires DETAIL debug flag to match error regex on xccl
-             if TEST_XPU:
+            if TEST_XPU:
                 dist.set_debug_level(dist.DebugLevel.DETAIL)
             backend_pg = dist.new_group(
                 ranks=list(range(int(self.world_size))),


### PR DESCRIPTION
## Issue: 
https://github.com/intel/torch-xpu-ops/issues/2701; https://github.com/intel/torch-xpu-ops/issues/2702
The default error message for XCCL backend does not match for these tests causing failure.
## Fix:
 Enable TORCH_DISTRIBUTED_DEBUG=DETAIL flag for XCCL backend for these tests. The error generated on using this flag matches the expected string.